### PR TITLE
Fix simulcast issues

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -229,6 +229,9 @@ func (d *DownTrack) SwitchSpatialLayer(targetLayer int32, setAsMax bool) error {
 	if d.trackType != SimulcastDownTrack {
 		return ErrSpatialNotSupported
 	}
+	if setAsMax && d.maxSpatialLayer.get() != targetLayer {
+		d.maxSpatialLayer.set(targetLayer)
+	}
 	if !d.receiver.HasSpatialLayer(targetLayer) {
 		return ErrSpatialLayerNotFound
 	}
@@ -236,11 +239,7 @@ func (d *DownTrack) SwitchSpatialLayer(targetLayer int32, setAsMax bool) error {
 	if d.CurrentSpatialLayer() == targetLayer {
 		return nil
 	}
-
 	d.targetSpatialLayer.set(targetLayer)
-	if setAsMax {
-		d.maxSpatialLayer.set(targetLayer)
-	}
 	return nil
 }
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -207,7 +207,7 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 		w.downTrackMu.RLock()
 		for _, dt := range w.downTracks {
 			if dt != nil {
-				if (bestQualityFirst && layer > dt.CurrentSpatialLayer()) ||
+				if (bestQualityFirst && layer > dt.CurrentSpatialLayer() && layer <= dt.maxSpatialLayer.get()) ||
 					(!bestQualityFirst && layer < dt.CurrentSpatialLayer()) {
 					_ = dt.SwitchSpatialLayer(layer, false)
 				}

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -166,7 +166,7 @@ func (r *router) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRe
 
 	recv, ok := r.receivers[trackID]
 	if !ok {
-		recv = NewWebRTCReceiver(receiver, track, r.id, WithPliThrottle(r.config.PliThrottle*1e6))
+		recv = NewWebRTCReceiver(receiver, track, r.id, WithPliThrottle(r.config.PliThrottle*1e6), WithStreamTrackers())
 		r.receivers[trackID] = recv
 		recv.SetRTCPCh(r.rtcpCh)
 		recv.OnCloseHandler(func() {


### PR DESCRIPTION
* Set active layer detection as default
* Fix problem with downtrack layer preference. If downtrack sets preferred layer higher than currently available, that preference was ignored. This could cause downstrack to get higher layer than preferred once that layer becomes available in uptrack.