### PR TITLE
Fixing wrong payload type issue

### DIFF
--- a/pkg/sfu/publisher.go
+++ b/pkg/sfu/publisher.go
@@ -80,6 +80,7 @@ func NewPublisher(id string, session Session, cfg *WebRTCTransportConfig) (*Publ
 			"mediaSSRC", track.SSRC(),
 			"rid", track.RID(),
 			"stream_id", track.StreamID(),
+			"PayloadType", track.PayloadType(),
 		)
 
 		r, pub := p.router.AddReceiver(receiver, track, track.ID(), track.StreamID())
@@ -370,7 +371,7 @@ func (p *Publisher) createRelayTrack(track *webrtc.TrackRemote, receiver Receive
 		Channels:     codec.Channels,
 		SDPFmtpLine:  codec.SDPFmtpLine,
 		RTCPFeedback: []webrtc.RTCPFeedback{{"nack", ""}, {"nack", "pli"}},
-	}, receiver, p.cfg.BufferFactory, p.id, p.cfg.Router.MaxPacketTrack)
+	}, receiver, p.cfg.BufferFactory, p.id, p.cfg.Router.MaxPacketTrack, 0)
 	if err != nil {
 		Logger.V(1).Error(err, "Create Relay downtrack err", "peer_id", p.id)
 		return err

--- a/pkg/sfu/relaypeer.go
+++ b/pkg/sfu/relaypeer.go
@@ -128,7 +128,7 @@ func (r *RelayPeer) createRelayTrack(track *webrtc.TrackRemote, receiver Receive
 		Channels:     codec.Channels,
 		SDPFmtpLine:  codec.SDPFmtpLine,
 		RTCPFeedback: []webrtc.RTCPFeedback{{"nack", ""}, {"nack", "pli"}},
-	}, receiver, r.config.BufferFactory, r.ID(), r.config.Router.MaxPacketTrack)
+	}, receiver, r.config.BufferFactory, r.ID(), r.config.Router.MaxPacketTrack, 0)
 	if err != nil {
 		Logger.V(1).Error(err, "Create Relay downtrack err", "peer_id", r.ID())
 		return err

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -257,7 +257,7 @@ func (r *router) AddDownTrack(sub *Subscriber, recv Receiver) (*DownTrack, error
 		Channels:     codec.Channels,
 		SDPFmtpLine:  codec.SDPFmtpLine,
 		RTCPFeedback: []webrtc.RTCPFeedback{{"goog-remb", ""}, {"nack", ""}, {"nack", "pli"}},
-	}, recv, r.bufferFactory, sub.id, r.config.MaxPacketTrack)
+	}, recv, r.bufferFactory, sub.id, r.config.MaxPacketTrack, uint8(recv.Codec().PayloadType))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Passing upstream track payload type to downtrack. Downtrack has issue
  finding correct payload type when codec list contains codecs from all
transceivers. This makes it difficult to find correct payload type in
case where different payload type codecs contain same params (fmtp line)